### PR TITLE
Cors plug added before to load router

### DIFF
--- a/lib/ex_vote_web/endpoint.ex
+++ b/lib/ex_vote_web/endpoint.ex
@@ -21,6 +21,8 @@ defmodule ExVoteWeb.Endpoint do
 
   plug Plug.Logger
 
+  plug CORSPlug
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],


### PR DESCRIPTION
Added CORS plug in endpoint.ex file because API not works correctly without it. It needs to load before router 